### PR TITLE
replace manual relocation stuff with generated data by sjasmplus

### DIFF
--- a/src/input.asm
+++ b/src/input.asm
@@ -7,7 +7,7 @@
                 OUTPUT  build/input.bin
 
                 org     $0000
-                relocate_start
+                relocate_start high             ; MSB-mode of sjasmplus v1.20.0 to target high-byte relocation
 
 ; ******************************************************
 ; Game Input NextBASIC Driver
@@ -419,5 +419,4 @@ jump_table
 
                 relocate_end
 
-                ; -1 to target high-byte of words (requirement for NextZXOS driver ABI)
-                relocate_table -1
+                relocate_table

--- a/src/input_drv.asm
+++ b/src/input_drv.asm
@@ -20,9 +20,6 @@
 
         include "build/input.sym"
 
-relocs  equ     (reloc_end-reloc_start)/2
-
-
 ; ***************************************************************************
 ; * .DRV file header                                                        *
 ; ***************************************************************************
@@ -41,7 +38,7 @@ relocs  equ     (reloc_end-reloc_start)/2
 				; 7-bit unique driver id in bits 0..6
                                 ; bit 7=1 if to be called on IM1 interrupts
 
-        defb    relocs          ; number of relocation entries (0..255)
+        defb    relocate_count  ; number of relocation entries (0..255)
 
         defb    $80+$00         ; number of additional 8K DivMMC RAM banks
                                 ; required (0..8); call init/shutdown


### PR DESCRIPTION
IMO it's better to leave the relocation data generation to the assembler, the manual tracking is error prone and more tedious.